### PR TITLE
Capture journal entry DTO in test

### DIFF
--- a/tests/InsightLog.Tests.Integration/JournalEntryEndpointTests.cs
+++ b/tests/InsightLog.Tests.Integration/JournalEntryEndpointTests.cs
@@ -46,8 +46,11 @@ public class JournalEntryEndpointTests(CustomWebApplicationFactory factory) : IC
         var response = await _client.PostAsJsonAsync(_baseUrl, command);
         response.EnsureSuccessStatusCode();
 
+        var dto = await response.Content.ReadFromJsonAsync<JournalEntryDto>();
+
         // Assert
         FakeJournalEntryCreatedHandler.FiredEvents.Should().ContainSingle();
+        FakeJournalEntryCreatedHandler.FiredEvents.Single().Should().Be(dto!.Id);
     }
 
 }


### PR DESCRIPTION
## Summary
- return the posted `JournalEntryDto` in the event firing test
- assert that the fired domain event id matches the returned dto

## Testing
- `dotnet test --no-build tests/InsightLog.Tests.Integration/InsightLog.Tests.Integration.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840d0394a5083319c793187f8749ae6