### PR TITLE
Enable AppHost to run API and Blazor

### DIFF
--- a/src/InsightLog.AppHost/InsightLog.AppHost.csproj
+++ b/src/InsightLog.AppHost/InsightLog.AppHost.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\InsightLog.API\InsightLog.API.csproj" />
+    <ProjectReference Include="..\InsightLog.Blazor\InsightLog.Blazor.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/InsightLog.AppHost/Program.cs
+++ b/src/InsightLog.AppHost/Program.cs
@@ -1,5 +1,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<Projects.InsightLog_API>("insightlog-api");
+var api = builder.AddProject<Projects.InsightLog_API>("insightlog-api");
+builder.AddProject<Projects.InsightLog_Blazor>("insightlog-blazor")
+       .WithReference(api);
 
 builder.Build().Run();


### PR DESCRIPTION
## Summary
- update AppHost project references to include the Blazor frontend
- launch the Blazor project from `Program.cs` alongside the API

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840df0603308331bac32b863e8a145b