### PR TITLE
Add MudBlazor layout integration

### DIFF
--- a/src/InsightLog.Blazor/InsightLog.Blazor.csproj
+++ b/src/InsightLog.Blazor/InsightLog.Blazor.csproj
@@ -7,4 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\InsightLog.Application\InsightLog.Application.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" Version="6.7.0" />
+  </ItemGroup>
 </Project>

--- a/src/InsightLog.Blazor/Pages/_Host.cshtml
+++ b/src/InsightLog.Blazor/Pages/_Host.cshtml
@@ -12,10 +12,12 @@
     <title>InsightLog</title>  
     <base href="~" />  
     <link rel="stylesheet" href="InsightLog.Blazor.css" />
-    <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />  
+    <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 </head>  
 <body>  
     <component type="typeof(App)" render-mode="ServerPrerendered" />  
-    <script src="_framework/blazor.web.js"></script>  
+    <script src="_framework/blazor.web.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>  
 </html>

--- a/src/InsightLog.Blazor/Program.cs
+++ b/src/InsightLog.Blazor/Program.cs
@@ -1,5 +1,6 @@
 using InsightLog.Blazor;
 using InsightLog.Blazor.Services;
+using MudBlazor.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents()
@@ -11,6 +12,7 @@ builder.Services.AddHttpClient("Api", client =>
 });
 
 builder.Services.AddScoped<JournalEntryService>();
+builder.Services.AddMudServices();
 
 var app = builder.Build();
 

--- a/src/InsightLog.Blazor/Shared/MainLayout.razor
+++ b/src/InsightLog.Blazor/Shared/MainLayout.razor
@@ -1,13 +1,27 @@
 @inherits LayoutComponentBase
 
-<div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
+<MudThemeProvider>
+    <MudLayout>
+        <MudAppBar Color="Color.Primary">
+            <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
+            <MudText Typo="Typo.h6" Class="ml-2">InsightLog</MudText>
+        </MudAppBar>
 
-    <main>
-        <article>
+        <MudDrawer Elevation="1" Variant="DrawerVariant.Responsive" @bind-Open="_drawerOpen" Breakpoint="Breakpoint.Md">
+            <NavMenu />
+        </MudDrawer>
+
+        <MudMainContent>
             @Body
-        </article>
-    </main>
-</div>
+        </MudMainContent>
+    </MudLayout>
+</MudThemeProvider>
+
+@code {
+    private bool _drawerOpen = true;
+
+    private void ToggleDrawer()
+    {
+        _drawerOpen = !_drawerOpen;
+    }
+}

--- a/src/InsightLog.Blazor/Shared/NavMenu.razor
+++ b/src/InsightLog.Blazor/Shared/NavMenu.razor
@@ -1,6 +1,4 @@
-<nav>
-    <ul>
-        <li><NavLink href="/" Match="NavLinkMatch.All">Home</NavLink></li>
-        <li><NavLink href="/journal" >Journal Entries</NavLink></li>
-    </ul>
-</nav>
+<MudNavMenu>
+    <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+    <MudNavLink Href="/journal" Icon="@Icons.Material.Filled.List">Journal Entries</MudNavLink>
+</MudNavMenu>

--- a/src/InsightLog.Blazor/_Imports.razor
+++ b/src/InsightLog.Blazor/_Imports.razor
@@ -4,3 +4,4 @@
 
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
+@using MudBlazor


### PR DESCRIPTION
## Summary
- reference MudBlazor in the Blazor project
- register MudBlazor services
- update the default layout and navigation with MudBlazor components
- include MudBlazor CSS and JS in the host page

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dec798a083318570291eb542278b