### PR TITLE
Add Blazor journal entry dialog

### DIFF
--- a/src/InsightLog.API/Controllers/V1/JournalEntriesController.cs
+++ b/src/InsightLog.API/Controllers/V1/JournalEntriesController.cs
@@ -29,14 +29,14 @@ public class JournalEntriesController(IMediator mediator) : ControllerBase
     /// </summary>
     /// <param name="command">The journal entry creation details.</param>
     /// <returns>The created journal entry.</returns>
-    /// <response code="200">Returns the created journal entry</response>
+    /// <response code="201">Returns the created journal entry</response>
     /// <response code="400">If the request is invalid</response>
     [HttpPost]
-    [ProducesResponseType(typeof(JournalEntryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(JournalEntryDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<JournalEntryDto>> Create([FromBody] CreateJournalEntry.Command command)
     {
         var result = await mediator.Send(command);
-        return Ok(result);
+        return Created(string.Empty, result);
     }
 }

--- a/src/InsightLog.Blazor/Pages/Journal.razor
+++ b/src/InsightLog.Blazor/Pages/Journal.razor
@@ -2,6 +2,10 @@
 
 <h1>Journal Entries</h1>
 
+<MudButton StartIcon="@Icons.Material.Filled.Add" OnClick="OpenCreateDialog" Color="Color.Primary" Variant="Variant.Filled" class="mb-4">
+    New Entry
+</MudButton>
+
 @if (entries is null)
 {
     <p><em>Loading...</em></p>
@@ -31,4 +35,19 @@ else
 
     [Inject]
     public JournalEntryService JournalService { get; set; } = default!;
+
+    [Inject]
+    public IDialogService DialogService { get; set; } = default!;
+
+    private async Task OpenCreateDialog()
+    {
+        var dialog = DialogService.Show<JournalCreate>("New Journal Entry");
+        var result = await dialog.Result;
+        if (!result.Cancelled && result.Data is JournalEntryDto dto)
+        {
+            entries ??= new();
+            entries.Insert(0, dto);
+            StateHasChanged();
+        }
+    }
 }

--- a/src/InsightLog.Blazor/Pages/JournalCreate.razor
+++ b/src/InsightLog.Blazor/Pages/JournalCreate.razor
@@ -1,0 +1,51 @@
+@using System.ComponentModel.DataAnnotations
+
+<EditForm Model="@entry" OnValidSubmit="CreateEntry">
+    <DataAnnotationsValidator />
+    <MudTextField Label="Content" @bind-Value="entry.Content" Lines="5" Required="true" />
+    <MudDatePicker Label="Created" @bind-Date="entry.CreatedDate" />
+    <MudStack Row="true" Spacing="2" Class="mt-4">
+        <MudButton Type="Submit" Color="Color.Primary" Variant="Variant.Filled">Save</MudButton>
+        <MudButton OnClick="Cancel" Color="Color.Secondary" Variant="Variant.Text">Cancel</MudButton>
+    </MudStack>
+</EditForm>
+
+@code {
+    private JournalEntryModel entry = new();
+
+    [Inject]
+    public JournalEntryService JournalService { get; set; } = default!;
+
+    [Inject]
+    public ISnackbar Snackbar { get; set; } = default!;
+
+    [CascadingParameter]
+    public MudDialogInstance MudDialog { get; set; } = default!;
+
+    private async Task CreateEntry()
+    {
+        var command = new CreateJournalEntry.Command(
+            new UserId(Guid.NewGuid()),
+            entry.Content!,
+            entry.CreatedDate,
+            null);
+
+        var dto = await JournalService.CreateAsync(command);
+        Snackbar.Add("Entry created", Severity.Success);
+        MudDialog.Close(DialogResult.Ok(dto));
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    public class JournalEntryModel
+    {
+        [Required]
+        [MaxLength(5000)]
+        public string Content { get; set; } = string.Empty;
+
+        public DateTime? CreatedDate { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/src/InsightLog.Blazor/Services/JournalEntryService.cs
+++ b/src/InsightLog.Blazor/Services/JournalEntryService.cs
@@ -1,4 +1,5 @@
 using InsightLog.Application.Dtos;
+using InsightLog.Application.Features.JournalEntries;
 namespace InsightLog.Blazor.Services;
 
 public class JournalEntryService(HttpClient client)
@@ -7,6 +8,13 @@ public class JournalEntryService(HttpClient client)
     {
         return await client.GetFromJsonAsync<List<JournalEntryDto>>($"api/v1/JournalEntries/user/{userId}")
                ?? [];
+    }
+
+    public async Task<JournalEntryDto?> CreateAsync(CreateJournalEntry.Command command)
+    {
+        var response = await client.PostAsJsonAsync("api/v1/journalentries", command);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<JournalEntryDto>();
     }
 }
 

--- a/src/InsightLog.Blazor/Shared/MainLayout.razor
+++ b/src/InsightLog.Blazor/Shared/MainLayout.razor
@@ -2,6 +2,7 @@
 
 <MudThemeProvider />
 <MudPopoverProvider />
+<MudDialogProvider />
 
 <MudLayout>
     <MudAppBar Elevation="1">

--- a/src/InsightLog.Blazor/_Imports.razor
+++ b/src/InsightLog.Blazor/_Imports.razor
@@ -2,6 +2,9 @@
 @using InsightLog.Blazor.Services
 @using InsightLog.Blazor.Shared
 
+@using InsightLog.Application.Features.JournalEntries
+@using InsightLog.Domain.Identifiers
+
 @using MudBlazor
 
 @using System.Net.Http


### PR DESCRIPTION
## Summary
- open a dialog to create journal entries from the journal page
- show dialog provider in the layout
- drop the `New Entry` link from the nav menu
- remove the route from `JournalCreate` so it can be used in a dialog

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fcee17708331ac0637f6c1dbd363