### PR TITLE
Implement CRUD operations for journals

### DIFF
--- a/src/InsightLog.API/Controllers/V1/JournalEntriesController.cs
+++ b/src/InsightLog.API/Controllers/V1/JournalEntriesController.cs
@@ -1,4 +1,5 @@
-﻿using InsightLog.Application.Features.JournalEntries.Queries;
+using InsightLog.Application.Features.JournalEntries.Queries;
+using InsightLog.Application.Features.JournalEntries;
 
 namespace InsightLog.API.Controllers.V1;
 
@@ -61,5 +62,52 @@ public class JournalEntriesController(IMediator mediator) : ControllerBase
     {
         var result = await mediator.Send(command);
         return Created(string.Empty, result);
+    }
+
+    /// <summary>
+    /// Updates an existing journal entry.
+    /// </summary>
+    /// <param name="id">Journal entry identifier.</param>
+    /// <param name="command">Updated journal entry details.</param>
+    /// <returns>The updated journal entry.</returns>
+    /// <response code="200">Returns the updated entry</response>
+    /// <response code="404">If the entry is not found</response>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(JournalEntryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<JournalEntryDto>> Update([FromRoute] Guid id, [FromBody] UpdateJournalEntry.Command command)
+    {
+        if (id != command.Id)
+        {
+            return BadRequest();
+        }
+
+        var result = await mediator.Send(command);
+        if (result is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Deletes a journal entry.
+    /// </summary>
+    /// <param name="id">Journal entry identifier.</param>
+    /// <response code="204">Entry successfully deleted</response>
+    /// <response code="404">If the entry is not found</response>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete([FromRoute] Guid id)
+    {
+        var result = await mediator.Send(new DeleteJournalEntry.Command(id));
+        if (!result)
+        {
+            return NotFound();
+        }
+
+        return NoContent();
     }
 }

--- a/src/InsightLog.Application/Features/JournalEntries/DeleteJournalEntry.cs
+++ b/src/InsightLog.Application/Features/JournalEntries/DeleteJournalEntry.cs
@@ -1,0 +1,30 @@
+namespace InsightLog.Application.Features.JournalEntries;
+
+public static class DeleteJournalEntry
+{
+    public record Command(Guid Id) : IRequest<bool>;
+
+    public class Handler(IJournalEntryRepository repository, IUnitOfWork unitOfWork) : IRequestHandler<Command, bool>
+    {
+        public async Task<bool> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var entry = await repository.GetByIdAsync(new JournalEntryId(request.Id), cancellationToken);
+            if (entry is null || entry.IsDeleted)
+            {
+                return false;
+            }
+
+            entry.SoftDelete();
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.Id).NotEqual(Guid.Empty);
+        }
+    }
+}

--- a/src/InsightLog.Application/Features/JournalEntries/UpdateJournalEntry.cs
+++ b/src/InsightLog.Application/Features/JournalEntries/UpdateJournalEntry.cs
@@ -1,0 +1,40 @@
+using InsightLog.Application.Mappings;
+
+namespace InsightLog.Application.Features.JournalEntries;
+
+public static class UpdateJournalEntry
+{
+    public record Command(
+        Guid Id,
+        string Content,
+        List<string>? MoodTags
+    ) : IRequest<JournalEntryDto?>;
+
+    public class Handler(IJournalEntryRepository repository, IUnitOfWork unitOfWork) : IRequestHandler<Command, JournalEntryDto?>
+    {
+        public async Task<JournalEntryDto?> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var entry = await repository.GetByIdAsync(new JournalEntryId(request.Id), cancellationToken);
+            if (entry is null || entry.IsDeleted)
+            {
+                return null;
+            }
+
+            entry.Edit(request.Content, request.MoodTags);
+
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return entry.ToDto();
+        }
+    }
+
+    public class Validator : AbstractValidator<Command>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.Id).NotEqual(Guid.Empty);
+            RuleFor(x => x.Content).NotEmpty();
+            RuleFor(x => x.Content).MaximumLength(5000);
+        }
+    }
+}

--- a/src/InsightLog.Infrastructure/Persistence/Repositories/JournalEntryRepository.cs
+++ b/src/InsightLog.Infrastructure/Persistence/Repositories/JournalEntryRepository.cs
@@ -16,13 +16,13 @@ public class JournalEntryRepository(InsightLogDbContext context) : IJournalEntry
     public async Task<JournalEntry?> GetByIdAsync(JournalEntryId id, CancellationToken cancellationToken)
     {
         return await context.JournalEntries
-            .SingleOrDefaultAsync(j => j.Id == id, cancellationToken);
+            .SingleOrDefaultAsync(j => j.Id == id && !j.IsDeleted, cancellationToken);
     }
 
     public async Task<List<JournalEntry>> GetByUserIdAsync(UserId userId, CancellationToken cancellationToken)
     {
         return await context.JournalEntries
-            .Where(j => j.UserId == userId)
+            .Where(j => j.UserId == userId && !j.IsDeleted)
             .ToListAsync(cancellationToken);
     }
 

--- a/src/InsightLog.Tests.Unit/Features/JournalEntries/UpdateJournalEntryTests.cs
+++ b/src/InsightLog.Tests.Unit/Features/JournalEntries/UpdateJournalEntryTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+
+using InsightLog.Application.Features.JournalEntries;
+using InsightLog.Application.Interfaces;
+using InsightLog.Domain.Entities;
+using InsightLog.Domain.Identifiers;
+
+using Moq;
+
+namespace InsightLog.Tests.Unit.Features.JournalEntries;
+
+public class UpdateJournalEntryTests
+{
+    private readonly Mock<IJournalEntryRepository> _repoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+
+    [Fact]
+    public async Task Handler_Should_Update_Entry_And_Return_Dto()
+    {
+        var entry = new JournalEntry(new UserId(Guid.NewGuid()), "orig");
+        _repoMock.Setup(r => r.GetByIdAsync(entry.Id, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(entry);
+
+        var command = new UpdateJournalEntry.Command(entry.Id.Value, "updated", ["tag1"]);
+
+        var handler = new UpdateJournalEntry.Handler(_repoMock.Object, _unitOfWorkMock.Object);
+
+        var result = await handler.Handle(command, default);
+
+        result.Should().NotBeNull();
+        result!.Content.Should().Be("updated");
+        entry.Content.Should().Be("updated");
+    }
+}

--- a/src/InsightLog.Tests.Unit/Features/JournalEntries/UpdateJournalEntryValidatorTests.cs
+++ b/src/InsightLog.Tests.Unit/Features/JournalEntries/UpdateJournalEntryValidatorTests.cs
@@ -1,0 +1,28 @@
+using FluentValidation.TestHelper;
+
+using InsightLog.Application.Features.JournalEntries;
+
+namespace InsightLog.Tests.Unit.Features.JournalEntries;
+
+public class UpdateJournalEntryValidatorTests
+{
+    private readonly UpdateJournalEntry.Validator _validator = new();
+
+    [Fact]
+    public void Should_Fail_When_Content_Is_Empty()
+    {
+        var command = new UpdateJournalEntry.Command(Guid.NewGuid(), string.Empty, null);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Content);
+    }
+
+    [Fact]
+    public void Should_Fail_When_Id_Is_Empty()
+    {
+        var command = new UpdateJournalEntry.Command(Guid.Empty, "text", null);
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.Id);
+    }
+}

--- a/tests/InsightLog.Tests.Integration/JournalEntryEndpointTests.cs
+++ b/tests/InsightLog.Tests.Integration/JournalEntryEndpointTests.cs
@@ -75,4 +75,48 @@ public class JournalEntryEndpointTests(CustomWebApplicationFactory factory) : IC
         fetched!.Id.Should().Be(created.Id);
         fetched.Content.Should().Be(createCommand.Content);
     }
+
+    [Fact]
+    public async Task UpdateJournalEntry_Should_Return_Updated_Entry()
+    {
+        var createCommand = new CreateJournalEntry.Command(
+            new UserId(Guid.NewGuid()),
+            "to update",
+            DateTime.UtcNow,
+            []);
+
+        var createResponse = await _client.PostAsJsonAsync(_url, createCommand);
+        createResponse.EnsureSuccessStatusCode();
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JournalEntryDto>();
+
+        var updateCommand = new UpdateJournalEntry.Command(created!.Id, "updated", null);
+
+        var updateResponse = await _client.PutAsJsonAsync($"{_url}/{created.Id}", updateCommand);
+        updateResponse.EnsureSuccessStatusCode();
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<JournalEntryDto>();
+        updated!.Content.Should().Be("updated");
+    }
+
+    [Fact]
+    public async Task DeleteJournalEntry_Should_Remove_Entry()
+    {
+        var createCommand = new CreateJournalEntry.Command(
+            new UserId(Guid.NewGuid()),
+            "to delete",
+            DateTime.UtcNow,
+            []);
+
+        var createResponse = await _client.PostAsJsonAsync(_url, createCommand);
+        createResponse.EnsureSuccessStatusCode();
+
+        var created = await createResponse.Content.ReadFromJsonAsync<JournalEntryDto>();
+
+        var deleteResponse = await _client.DeleteAsync($"{_url}/{created!.Id}");
+        deleteResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.NoContent);
+
+        var getResponse = await _client.GetAsync($"{_url}/{created.Id}");
+        getResponse.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
## Summary
- add update and delete commands for journal entries
- hide deleted entries in repository queries
- expose PUT and DELETE endpoints
- test update/delete handlers and endpoints

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843022032b0833194a721384481df49